### PR TITLE
Fix typos in Shuttle.ts affecting `productId` and `interface`

### DIFF
--- a/packages/core/src/Shuttle.ts
+++ b/packages/core/src/Shuttle.ts
@@ -34,8 +34,8 @@ export class Shuttle extends EventEmitter<ShuttleEvents> {
 				if (product.vendorId === deviceInfo.vendorId && product.productId === deviceInfo.productId) {
 					return {
 						product,
-						productId: product.vendorId,
-						interface: product.productId,
+						productId: deviceInfo.productId,
+						interface: deviceInfo.interface,
 					}
 				}
 			}


### PR DESCRIPTION
In the nested function `findProduct()`, the properties  `productId` and `interface` were being assigned the incorrect values. This PR fixes it.