### PR TITLE
Fix: A very old Contour Shuttle Pro v1 vendor ID and model number

### DIFF
--- a/packages/core/src/products.ts
+++ b/packages/core/src/products.ts
@@ -2,7 +2,7 @@
  * This file contains information about the various Shuttle devices
  */
 
-export const VENDOR_IDS = [0x0b33, 0x5F3]
+export const VENDOR_IDS = [0x0b33, 0x5f3]
 
 export enum ProductModelId {
 	ShuttleProV1 = 'shuttlepro_v1',
@@ -32,7 +32,8 @@ export const PRODUCTS: Record<ProductModelId, Product> = {
 		interface: 0,
 		buttonBits: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
 	},
-	[ProductModelId.ShuttleProV1a]: { // S/N lower than 00100000
+	[ProductModelId.ShuttleProV1a]: {
+		// S/N lower than 00100000 ? Found in S/N 0005xxxx
 		productModelId: ProductModelId.ShuttleProV1,
 		name: 'ShuttlePro v1',
 		vendorId: VENDOR_IDS[1],

--- a/packages/core/src/products.ts
+++ b/packages/core/src/products.ts
@@ -2,10 +2,11 @@
  * This file contains information about the various Shuttle devices
  */
 
-export const VENDOR_IDS = [0x0b33]
+export const VENDOR_IDS = [0x0b33, 0x5F3]
 
 export enum ProductModelId {
 	ShuttleProV1 = 'shuttlepro_v1',
+	ShuttleProV1a = 'shuttlepro_v1_older',
 	ShuttleXpress = 'shuttlexpress',
 	ShuttleProV2 = 'shuttlepro_v2',
 }
@@ -28,6 +29,14 @@ export const PRODUCTS: Record<ProductModelId, Product> = {
 		name: 'ShuttlePro v1',
 		vendorId: VENDOR_IDS[0],
 		productId: 0x0010,
+		interface: 0,
+		buttonBits: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
+	},
+	[ProductModelId.ShuttleProV1a]: { // S/N lower than 00100000
+		productModelId: ProductModelId.ShuttleProV1,
+		name: 'ShuttlePro v1',
+		vendorId: VENDOR_IDS[1],
+		productId: 0x0240,
 		interface: 0,
 		buttonBits: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
 	},


### PR DESCRIPTION
A very old Contour Shuttle Pro v1 has a different vendor ID and model number than the later v1 models. (S/N 0005xxxx vs S/N 001xxxxx). Everything else about it seems to work identically.

(Fix tested in Companion, which will need a slight change too, because the old vendor ID appears to be XKeys!)
