### PR TITLE
fix: treat null interface as catch-all

### DIFF
--- a/packages/core/src/Shuttle.ts
+++ b/packages/core/src/Shuttle.ts
@@ -34,13 +34,13 @@ export class Shuttle extends EventEmitter<ShuttleEvents> {
 				if (
 					product.vendorId === deviceInfo.vendorId &&
 					product.productId === deviceInfo.productId &&
-					product.interface === deviceInfo.interface
+					(deviceInfo.interface === null || product.interface === deviceInfo.interface)
 				) {
 					return {
 						product,
 						vendorId: deviceInfo.vendorId,
 						productId: deviceInfo.productId,
-						interface: deviceInfo.interface,
+						interface: product.interface,
 					}
 				}
 			}


### PR DESCRIPTION
Unlike node, the webhid version always initializes `interface` it with `null`, see: https://github.com/nytamin/contour-shuttle/blob/eaabb227df96af6ca21b0ace00517a72c0223006/packages/webhid/src/methods.ts#L40 ...which was causing no device to be accepted. Now if `null`, matching against `product.interface` is omitted and `product.interface` is assumed to be the `interface` that will be returned in e.g. `ShuttleInfo`.

Fixes https://github.com/nytamin/contour-shuttle/issues/4